### PR TITLE
CFP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/cfp.md
+++ b/.github/ISSUE_TEMPLATE/cfp.md
@@ -1,0 +1,43 @@
+---
+name: CFP
+about: StayAtHomeConf call for papers
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Hey there and thank you for submitting your talk to StayAtHomeConf !!!
+
+As you've probably heard, in the last weeks the world is struggling against the SARS-CoV-2 virus that is causing COVID-19 disease. For this reason, a lot of governments are declaring a national emergency, limiting freedom of movement and asking the population to stay at home and WFH. As a consequence, several events, conferences and meetups have been cancelled.
+
+StayAtHomeConf is here to help you with confinement and stream IT talks with the rest of the world.
+
+Please fill out this CFP to be considered for a talk. We are looking for unique use cases, technical talks, culture talks, and demos focused on any IT topics.
+
+StayAtHomeConf will be hosted on <date> beginning at <time> UTC and each speaker will have a 30 minute speaking slot. Please, it is important that the talk is no longer than 30 minutes.
+
+The CFP will close <date> at <time> GMT and we will send notices shortly thereafter. 
+
+Do the checklist before filing a CFP:
+
+- [ ] Is your talk related to the IT community?
+- [ ] Is your talk duration up to 30 minutes?
+- [ ] Do you have a reliable Internet connection?
+
+**Call For Papers form**
+
+* **Email**
+
+* **What is your name?**
+
+* **What is your GitHub ID?**
+
+* **What is your time zone***
+
+* **What is your preferred presentation time?**
+
+* **Provide a talk title**
+
+* **Provide a talk abstract**
+*Talk abstract best practices: topic + title + motivation + problem statement + approach + demo (if you're running one) + results + conclusions*

--- a/.github/ISSUE_TEMPLATE/cfp.md
+++ b/.github/ISSUE_TEMPLATE/cfp.md
@@ -37,6 +37,8 @@ Do the checklist before filing a CFP:
 
 * **What is your preferred presentation time?**
 
+* **Have you ever done similar talks? Where? What was the topic? Can you provide a link?**
+
 * **Provide a talk title**
 
 * **Provide a talk abstract**


### PR DESCRIPTION
This is a very first version of a GitHub issue template we can use to register the talks.
The idea behind is that the speaker can do the CFP using GitHub and full fil the template.